### PR TITLE
PERF: Optimize XmlRepair.cs

### DIFF
--- a/XmlRepair.Benchmark/XmlRepairBenchmark.cs
+++ b/XmlRepair.Benchmark/XmlRepairBenchmark.cs
@@ -3,6 +3,7 @@ using static XmlRepair.XmlRepair;
 
 namespace XmlRepair.Benchmark
 {
+    [MemoryDiagnoser]
     public class XmlRepairBenchmark
     {
         private static string xmlContent;

--- a/XmlRepair/XmlRepair.cs
+++ b/XmlRepair/XmlRepair.cs
@@ -16,9 +16,10 @@ namespace XmlRepair
         /// <returns></returns>
         public static string RepairRegex(string xmlContent)
         {
-            string re = @"[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF]";
-            return Regex.Replace(xmlContent, re, "");
+            return XmlRepairRegex.Replace(xmlContent, "");
         }
+
+        private static Regex XmlRepairRegex = new Regex(@"[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF]", RegexOptions.Compiled);
 
         /// <summary>
         /// Repairs content of xml file by copying only valid characters using string builder.


### PR DESCRIPTION
Hi @KlaraMinsterova, I've tried to make some performance optimizations to this repo. Following are the benchmark results before and after the changes:

**Benchmarks before changes:**
|                       Method |      Mean |     Error |   StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|----------------------------- |----------:|----------:|---------:|-------:|-------:|------:|----------:|
|         RepairRegexBenchmark | 107.36 us | 2.1433 us | 3.005 us | 2.6855 |      - |     - |  18.44KB |
| RepairStringBuilderBenchmark |  28.74 us | 0.5674 us | 1.159 us | 3.9673 | 0.1831 |     - |  25.38KB |

**Benchmarks after changes:**
|                       Method |     Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|----------------------------- |---------:|----------:|----------:|-------:|-------:|------:|----------:|
|         RepairRegexBenchmark | 94.62 us | 1.8523 us | 3.6128 us | 2.6855 |      - |     - |  18.34KB |
| RepairStringBuilderBenchmark | 27.93 us | 0.5550 us | 0.9273 us | 3.9673 | 0.1831 |     - |  25.38KB |

As you can see the benchmark durations (RepairRegexBenchmark) have gone down. I've also made sure that all the unit tests pass following these changes as well. Could you please confirm whether or not you think my changes are valid?

Thank you!